### PR TITLE
Enable the use of intent: URIs

### DIFF
--- a/app/src/main/java/com/github/fi3te/notificationcron/ui/NotificationService.kt
+++ b/app/src/main/java/com/github/fi3te/notificationcron/ui/NotificationService.kt
@@ -106,7 +106,7 @@ fun createNotification(context: Context, notificationCron: NotificationCron): No
         }
         .apply {
             uri?.let {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
+                val intent = Intent.parseUri(uri, 0)
                 val pendingIntent =
                     PendingIntent.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT)
                 setContentIntent(pendingIntent)


### PR DESCRIPTION
With `val intent = Intent.parseUri(uri, 0)` instead of `val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))` it is possible to use intent: URIs as onClickUri.

This can be used to launch the "contact diary" of https://github.com/corona-warn-app/cwa-app-android/ directly from the notification by specifying this URI: `intent:#Intent;component=de.rki.coronawarnapp/de.rki.coronawarnapp.ui.launcher.LauncherActivity;S.shortcut_extra=CONTACT_DIARY;end`